### PR TITLE
Add support for 'x' regex flag

### DIFF
--- a/regexbot.py
+++ b/regexbot.py
@@ -50,6 +50,8 @@ async def doit(chat, match):
             flags |= re.DOTALL
         elif f == 'g':
             count = 0
+        elif f == 'x':
+            flags |= re.VERBOSE
         else:
             await chat.reply('unknown flag: {}'.format(f))
             return


### PR DESCRIPTION
This allows writing "verbose" regex queries that ignore whitespace and support comments, which can enable people to write easier-to-understand regex strings.