### PR TITLE
Convert flags to lowercase characters

### DIFF
--- a/regexbot.py
+++ b/regexbot.py
@@ -41,7 +41,7 @@ async def doit(chat, match):
     # Build Python regex flags
     count = 1
     flags = 0
-    for f in fl:
+    for f in fl.lower():
         if f == 'i':
             flags |= re.IGNORECASE
         elif f == 'm':


### PR DESCRIPTION
Sometimes it happens to use an uppercase character as a flag and the bot won't recognize it as a valid flag. So we convert user's flag to lowercase to match the flag regardless of the character case