### PR TITLE
Fix not being able to sed sedded messages

### DIFF
--- a/regexbot.py
+++ b/regexbot.py
@@ -73,7 +73,7 @@ async def doit(message, match):
                     break  # msg is also set
 
         if substitution is not None:
-            await msg.reply(substitution)
+            return await msg.reply(substitution)
 
     except Exception as e:
         await message.reply('fuck me\n' + str(e))


### PR DESCRIPTION
This fix allows seds to work on what the bot sends as results. This used to work, but then during the telethon rewrite it got accidentally removed.

https://github.com/SijmenSchoon/regexbot/commit/348dba956b9e6c50a63f4e4daeb6299aa0267150#diff-411c09d70677bf50f3b61beda60c7c95L73-R64