### PR TITLE
Allow escaping of backslashes, fixes #11

### DIFF
--- a/regexbot.py
+++ b/regexbot.py
@@ -4,7 +4,7 @@ from collections import defaultdict, deque
 
 from telethon import TelegramClient, events
 
-SED_PATTERN = r'^s/((?:\\/|[^/])+)/((?:\\/|[^/])*)(/.*)?'
+SED_PATTERN = r'^s/((?:\\\S|[^/])+)/((?:\\\S|[^/])*)(/.*)?'
 GROUP0_RE = re.compile(r'(?<!\\)((?:\\\\)*)\\0')
 
 bot = TelegramClient(None, 6, 'eb06d4abfb49dc3eeb1aeb98ae0f581e')


### PR DESCRIPTION
Before, if you had `s/ /\\/g` what would happen is that the first `\` in the replacement half would be matched as `[^/]` and then `\/` would be matched, then `g` as `[^/]`. Making it match on `\\\S` will allow it to catch any escaping someone would want.